### PR TITLE
Show which user and host is used

### DIFF
--- a/lib/omc/stack_command.rb
+++ b/lib/omc/stack_command.rb
@@ -70,7 +70,9 @@ module Omc
     end
 
     def ssh_host
-      "#{@user.name}@#{instance[:public_ip]}"
+      host = "#{@user.name}@#{instance[:public_ip]}"
+      puts "Connecting to #{host}"
+      host
     end
 
     def account


### PR DESCRIPTION
It can sometimes be unclear which user is being user and host is being
accessed. Showing this information helps debug connection issues.